### PR TITLE
Fixed tensor_ReLU

### DIFF
--- a/hw0.py
+++ b/hw0.py
@@ -32,6 +32,9 @@ def tensor_sumproducts(A, B):
     return torch.dot(A, B)
 
 def tensor_ReLU(M):
-    return torch.max(torch.zeros(M.size()), M)
+    zeros = torch.zeros(M.size())
+    zeros = zeros.type(torch.LongTensor)
+    return torch.max(zeros, M)
+
 def tensor_ReLU_prime(M):
     return torch.clamp(M, min=0) * torch.reciprocal(torch.clamp(M, min=1e-8))


### PR DESCRIPTION
There was a type error in the existing implementation as ```torch. zeros()``` is created as a ```torch.FloatTensor``` data unit. Type-casted to  ```torch.LongTensor``` for comparison.